### PR TITLE
Create SurveyStation optional.txt

### DIFF
--- a/GameData/NotSoSimpleConstruction/Patches/SurveyStation optional.txt
+++ b/GameData/NotSoSimpleConstruction/Patches/SurveyStation optional.txt
@@ -1,0 +1,12 @@
+// This patch will add the survey station capability to all manned command parts
+// Change the file extension to .cfg to activate it
+
+@PART[*]:HAS[MODULE[ModuleCommand],MODULE[!ELSurveyStation],#CrewCapacity[>0]]:NEEDS[SimpleConstruction]:FOR[NotSoSimpleConstruction]
+{
+	MODULE
+	{
+		name = ELSurveyStation
+	}
+}
+
+// @LEGIONBOSS


### PR DESCRIPTION
I've seen that you kindly referred to me in SurveyStation.cfg, but my original intention was to add the survey station module to all manned command parts.
So, this optional file would do just that. It's a txt file, so MM won't pick it up right away, only if the user changes the extension to .cfg.
You may add any additional information (like versioning or some header) to this file as you see fit.